### PR TITLE
Fix fuzzy Spanish and French translations

### DIFF
--- a/po/extra/es.po
+++ b/po/extra/es.po
@@ -96,12 +96,10 @@ msgid "Add: “Help and FAQ” button"
 msgstr ""
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:27
-#, fuzzy
 msgid "Update: Dutch translations (@Vistaus)"
 msgstr "Adición: traducción en neerlandés (@Vistaus)"
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:28
-#, fuzzy
 msgid "Update: Italian translations (@albanobattistella)"
 msgstr "Adición: traducción en italiano (@ albanobattistella)"
 
@@ -110,7 +108,6 @@ msgid "Update: Use elementary Platform 7"
 msgstr ""
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:42
-#, fuzzy
 msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Adición: traducción en italiano (@ albanobattistella)"
 

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -97,12 +97,10 @@ msgid "Add: “Help and FAQ” button"
 msgstr ""
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:27
-#, fuzzy
 msgid "Update: Dutch translations (@Vistaus)"
 msgstr "Ajout : Traductions en néerlandais (@Vistaus)"
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:28
-#, fuzzy
 msgid "Update: Italian translations (@albanobattistella)"
 msgstr "Ajout : Traductions en italien (@albanobattistella)"
 
@@ -111,7 +109,6 @@ msgid "Update: Use elementary Platform 7"
 msgstr ""
 
 #: data/com.github.elfenware.obliviate.appdata.xml.in:42
-#, fuzzy
 msgid "Add: Italian translations (@albanobattistella)"
 msgstr "Ajout : Traductions en italien (@albanobattistella)"
 


### PR DESCRIPTION
"fuzzy" marks strings that changed their original string and didn't changed the translation, therefore they are not actually being applied. This PR removes "fuzzy" from Extra Spanish and French translation that @dar5hak translated in #28.