### PR TITLE
Setup gettext domain. Update Russian translation

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,16 @@ project (
 # Translation module
 i18n = import ('i18n')
 
+# Translations data
+config_data = configuration_data()
+config_data.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
+config_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+config_file = configure_file(
+    input: 'src/Config.vala.in',
+    output: '@BASENAME@',
+    configuration: config_data
+)
+
 # GNOME module
 gnome = import('gnome')
 
@@ -42,6 +52,7 @@ subdir ('src')
 # Executable
 executable (
     meson.project_name (),
+    config_file,
     asresources,
     sources,
     dependencies: dependencies,

--- a/po/com.github.elfenware.obliviate.pot
+++ b/po/com.github.elfenware.obliviate.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:59+0530\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,12 +16,13 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr ""
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr ""
 
@@ -61,15 +62,17 @@ msgstr ""
 msgid "Copy without symbols"
 msgstr ""
 
-#: src/MainView.vala:129 src/MainView.vala:214
+#: src/MainView.vala:130 src/MainView.vala:219
 #, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr ""
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr ""
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:59+0530\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: 2020-12-18 20:37+0530\n"
 "Last-Translator: Darshak Parikh, José Expósito\n"
 "Language-Team: Español\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr ""
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr "Copiado en el portapapeles"
 
@@ -63,16 +63,18 @@ msgstr "Copiar"
 msgid "Copy without symbols"
 msgstr ""
 
-#: src/MainView.vala:129 src/MainView.vala:214
-#, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr "Borrando el portapapeles en %.0f segundos"
+#: src/MainView.vala:130 src/MainView.vala:219
+#, fuzzy, c-format
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] "Borrando el portapapeles en %.0f segundos"
+msgstr[1] "Borrando el portapapeles en %.0f segundos"
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr "No se pudo derivar la contraseña"
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr "Borrado el portapapeles"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:59+0530\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: 2020-12-20 13:26+0530\n"
 "Last-Translator: Nathan Bonnemains (@NathanBnm)\n"
 "Language-Team: Français\n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr ""
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr "Copié dans le presse-papiers"
 
@@ -63,16 +63,18 @@ msgstr "Copier"
 msgid "Copy without symbols"
 msgstr ""
 
-#: src/MainView.vala:129 src/MainView.vala:214
+#: src/MainView.vala:130 src/MainView.vala:219
 #, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr ""
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] ""
+msgstr[1] ""
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr "Impossible d'obtenir le mot de passe"
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:59+0530\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: 2022-06-05 17:10+0100\n"
 "Last-Translator: Albano Battistella <albano_battistella@hotmail.com>\n"
 "Language-Team: Italian <LL@li.org>\n"
@@ -16,11 +16,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr "Aiuto e FAQ"
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr "Copiato negli appunti"
 
@@ -62,16 +62,18 @@ msgstr "Copia"
 msgid "Copy without symbols"
 msgstr "Copia senza simboli"
 
-#: src/MainView.vala:129 src/MainView.vala:214
-#, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr "Cancellazione appunti in %.0f secondi"
+#: src/MainView.vala:130 src/MainView.vala:219
+#, fuzzy, c-format
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] "Cancellazione appunti in %.0f secondi"
+msgstr[1] "Cancellazione appunti in %.0f secondi"
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr "Impossibile ottenere la password"
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr "Cancellato gli appunti"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-05 18:59+0530\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: 2022-06-05 19:32+0200\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0.1\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr "Hulp en veelgestelde vragen"
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr "Gekopieerd naar het klembord"
 
@@ -64,16 +64,18 @@ msgstr "Kopiëren"
 msgid "Copy without symbols"
 msgstr "Kopiëren zonder speciale tekens"
 
-#: src/MainView.vala:129 src/MainView.vala:214
-#, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr "Het klembord wordt over %.0f seconden gewist"
+#: src/MainView.vala:130 src/MainView.vala:219
+#, fuzzy, c-format
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] "Het klembord wordt over %.0f seconden gewist"
+msgstr[1] "Het klembord wordt over %.0f seconden gewist"
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr "Het wachtwoord kan niet worden opgehaald"
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr "Het klembord is gewist"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: com.github.elfenware.obliviate\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-04 14:45+0900\n"
+"POT-Creation-Date: 2022-12-03 16:06+0900\n"
 "PO-Revision-Date: 2022-11-04 14:19+0900\n"
 "Last-Translator: lenemter <lenemter@gmail.com>\n"
 "Language-Team: none\n"
@@ -15,12 +15,14 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
-#: src/MainWindow.vala:68
+#: src/MainWindow.vala:73
 msgid "Help and FAQ"
 msgstr "Помощь и ЧаВО"
 
-#: src/MainView.vala:46 src/MainView.vala:196
+#: src/MainView.vala:46 src/MainView.vala:200
 msgid "Copied to clipboard"
 msgstr "Скопировано в буфер обмена"
 
@@ -60,15 +62,18 @@ msgstr "Копировать"
 msgid "Copy without symbols"
 msgstr "Копировать без символов"
 
-#: src/MainView.vala:129 src/MainView.vala:214
+#: src/MainView.vala:130 src/MainView.vala:219
 #, c-format
-msgid "Clearing clipboard in %.0f seconds"
-msgstr "Буфер обмена будет очищен через %.0f секунд"
+msgid "Clearing clipboard in %.0f second"
+msgid_plural "Clearing clipboard in %.0f seconds"
+msgstr[0] "Буфер обмена будет очищен через %.0f секунду"
+msgstr[1] "Буфер обмена будет очищен через %.0f секунды"
+msgstr[2] "Буфер обмена будет очищен через %.0f секунд"
 
-#: src/MainView.vala:182
+#: src/MainView.vala:186
 msgid "Could not derive password"
 msgstr "Не удалось получить пароль"
 
-#: src/MainView.vala:206
+#: src/MainView.vala:210
 msgid "Cleared the clipboard"
 msgstr "Буфер обмена очищен"

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -27,6 +27,13 @@ public class Obliviate.Application : Granite.Application {
         );
     }
 
+    construct {
+        Intl.setlocale (LocaleCategory.ALL, "");
+        GLib.Intl.bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
+        GLib.Intl.textdomain (GETTEXT_PACKAGE);
+    }
+
     protected override void activate () {
         window = new MainWindow (this);
 

--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,0 +1,2 @@
+public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+public const string LOCALEDIR = @LOCALEDIR@;

--- a/src/MainView.vala
+++ b/src/MainView.vala
@@ -126,7 +126,11 @@ public class Obliviate.MainView : Gtk.Overlay {
         button_box.pack_start (copy_btn);
         button_box.pack_end (copy_without_symbols_btn);
 
-        clearing_label = new Gtk.Label (_ ("Clearing clipboard in %.0f seconds").printf (CLIPBOARD_LIFE)) {
+        clearing_label = new Gtk.Label (ngettext (
+            "Clearing clipboard in %.0f second",
+            "Clearing clipboard in %.0f seconds",
+            (ulong) CLIPBOARD_LIFE
+        ).printf (CLIPBOARD_LIFE)) {
             margin_top = 18,
             halign = Gtk.Align.START,
             hexpand = false


### PR DESCRIPTION
Turns out you need to setup gettext domain to use `ngettext` (https://github.com/elfenware/obliviate/pull/30)
Update Russian translation after https://github.com/elfenware/obliviate/pull/30
