### PR TITLE
Fix meson warning about find_library('libgcrypt')

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -41,7 +41,7 @@ dependencies = [
     dependency ('granite-7'),
     dependency ('gtk4'),
     declare_dependency (dependencies: [
-        meson.get_compiler ('c').find_library ('libgcrypt'),
+        meson.get_compiler ('c').find_library ('gcrypt'),
         meson.get_compiler ('vala').find_library ('gcrypt', dirs: join_paths (meson.current_source_dir (), 'vapi'))
     ])
 ]


### PR DESCRIPTION
Fixes #39

Fix the following warning when running the "meson setup" command:

    WARNING: find_library('libgcrypt') starting in "lib" only works by accident and is not portable
    Library libgcrypt found: YES
    Library gcrypt found: YES